### PR TITLE
Add a bore-sight to know where the front of the robot is pointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@
 5. [Running the project locally](#running-the-project-locally)
 6. [Building the project locally](#building-the-project-locally)
 7. [Project structure](#project-structure)
-8. [Citation](#citation)
+8. [Bore-Sight Feature](#bore-sight-feature)
+9. [Citation](#citation)
 
 ## 📸 Demo
 https://github.com/user-attachments/assets/419bda8b-d6a5-4f54-87b8-acef9d752226
+
+The demo now includes a bore-sight feature to indicate the front of the robot. This feature helps in visualizing the robot's orientation and front direction.
 
 ## 💡 Project Motivation
 **MicMasterFlex** was born out of challenges encountered during the [*Robots as Furniture*](https://github.com/robotsasfurniture/passive-sound-localization) project at [Brown University Human-centered Robotics Initiative](https://hcri.brown.edu/), where configuring a microphone array for sound localization required precise positioning of multiple microphones. 
@@ -81,6 +84,16 @@ Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page
 There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
 
 Any static assets, like images, can be placed in the `public/` directory.
+
+## 📝 Bore-Sight Feature
+
+The bore-sight feature in MicMasterFlex allows users to visualize the front direction of the robot. This is particularly useful for applications where the orientation of the robot is crucial. The bore-sight is represented by an arrow on the grid, indicating the direction the robot is facing.
+
+### How to Use
+
+1. **Adjust Bore-Sight Mode**: Select the "Adjust Bore-Sight" mode from the toolbar.
+2. **Drag to Adjust**: Click and drag on the grid to adjust the orientation of the bore-sight arrow.
+3. **Visual Feedback**: The arrow will update in real-time to show the new orientation.
 
 ## 📝 Citation
 


### PR DESCRIPTION
Fixes #19

Add a bore-sight feature to indicate the front of the robot.

* **MicMasterFlex Component**:
  - Import `ArrowUp` from `lucide-react`.
  - Add a new state variable `orientation` to manage the robot's orientation.
  - Update `handleMouseMove` to handle bore-sight orientation.
  - Add a visual representation (arrow) to show the robot's front direction.
  - Update `generateGridLines` to include the bore-sight feature.
  - Update `getCursor` function to include a new mode for adjusting the bore-sight.
  - Add a button to the toolbar for adjusting the bore-sight.

* **README.md**:
  - Add a section to describe the new bore-sight feature.
  - Update the demo section to include the bore-sight feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nicolasperez19/mic-master-flex/issues/19?shareId=XXXX-XXXX-XXXX-XXXX).