### PR TITLE
Add Lighthouse audit in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,23 @@ jobs:
           # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
           # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
-  deploy:
+  lighthouse:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Run Lighthouse CI
+        run: npm run lighthouse
+
+  deploy:
+    needs: [build, lighthouse]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 5. [Running the project locally](#running-the-project-locally)
 6. [Building the project locally](#building-the-project-locally)
 7. [Project structure](#project-structure)
-8. [Citation](#citation)
+8. [Lighthouse Audit](#lighthouse-audit)
+9. [Citation](#citation)
 
 ## 📸 Demo
 https://github.com/user-attachments/assets/419bda8b-d6a5-4f54-87b8-acef9d752226
@@ -81,6 +82,20 @@ Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page
 There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
 
 Any static assets, like images, can be placed in the `public/` directory.
+
+## 🌟 Lighthouse Audit
+
+We have integrated Lighthouse CI into our continuous integration process to ensure the highest quality of our web application. Lighthouse CI runs audits for performance, accessibility, best practices, SEO, and more.
+
+### Running Lighthouse CI Locally
+
+To run Lighthouse CI locally, use the following command:
+
+```sh
+npm run lighthouse
+```
+
+This will execute the Lighthouse CI audit and provide a detailed report of the results.
 
 ## 📝 Citation
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lighthouse": "lhci autorun"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
@@ -21,5 +22,8 @@
     "react-dom": "^18.3.1",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"
+  },
+  "devDependencies": {
+    "lighthouse-ci": "^0.9.0"
   }
 }


### PR DESCRIPTION
Fixes #23

Add Lighthouse audit to CI workflow.

* **package.json**:
  - Add `lighthouse-ci` as a dev dependency.
  - Add a new script `lighthouse` to run Lighthouse CI.

* **.github/workflows/deploy.yml**:
  - Add a new job `lighthouse` to run Lighthouse audit after the `build` job.
  - Use `actions/setup-node@v3` to set up Node.js.
  - Run `npm install` and `npm run lighthouse` in the `lighthouse` job.

* **README.md**:
  - Add a section about Lighthouse audit in the CI process.
  - Include instructions for running Lighthouse CI locally.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nicolasperez19/mic-master-flex/issues/23?shareId=XXXX-XXXX-XXXX-XXXX).